### PR TITLE
Updated KBD, VDU 19, VDU 20, MODE, colour api

### DIFF
--- a/build.z80
+++ b/build.z80
@@ -85,7 +85,11 @@ Code_Start		EQU	0x5B00			; Code straight after screen RAM
 
 			ALIGN 	256			; USER needs to be alignd to a page boundary
 
-@USER:			incbin "tests/mandlebrot.bbc"	; BASIC program to load into memory
+@USER:
+			incbin "tests/mandlebrot.bbc"	; BASIC program to load into memory
+;			incbin "tests/colours.bbc"
+;			incbin "tests/cursor.bbc"
+;			incbin "tests/environ.bbc"
 
 	 		SAVENEX OPEN "Z80/BBC Basic/build.nex", Code_Start, Stack_Top
 			SAVENEX CORE 3, 0, 0

--- a/misc.z80
+++ b/misc.z80
@@ -2,13 +2,14 @@
 ; Title:	BBC Basic for Spectrum Next - Miscellaneous helper functions
 ; Author:	Dean Belfield
 ; Created:	10/05/2021
-; Last Updated:	24/05/2021
+; Last Updated:	15/07/2021
 ;
 ; Modinfo:
 ; 15/05/2021:	Changed ASC_TO_HEX to ASC_TO_NUMBER; now parses decimal or hex
 ; 16/05/2021:	Added SWITCH_A
 ; 23/05/2021:	Added HLDE_TO_FPP, PRINT_BCD, NULLTOCR and CRTONULL
 ; 24/05/2021:	CRTONULL now preserves BC
+; 15/07/2021:	Added SKIPNOTSP, NULLTOSP and SPTONULL
 
 ; Read a number and convert to binary
 ; If prefixed with &, will read as hex, otherwise decimal
@@ -67,7 +68,16 @@ SKIPSP:			LD      A, (HL)
         		CP      ' '
         		RET     NZ
         		INC     HL
-        		JR      SKIPSP	
+        		JR      SKIPSP
+
+; Skip a string
+; HL: Pointer in string buffer
+;
+SKIPNOTSP:		LD	A, (HL)
+			CP	' '
+			RET	Z 
+			INC	HL 
+			JR	SKIPNOTSP
 
 ; Convert a character to upper case
 ;  A: Character to convert
@@ -80,6 +90,14 @@ UPPRC:  		AND     7FH
 
 ; Convert the buffer to a null terminated string and back
 ;	
+NULLTOSP:		PUSH	BC 
+			LD	B, 0
+			LD	C, ' '
+			JR	0F
+SPTONULL:		PUSH	BC 
+			LD	B, ' '
+			LD	C, 0
+			JR	0F
 NULLTOCR:		PUSH 	BC
 			LD	B, 0
 			LD	C, CR 

--- a/next_graphics.z80
+++ b/next_graphics.z80
@@ -25,6 +25,7 @@
 ; 15/06/2021:	Set screen window and origin as per BBC (1280x1024, bottom left = 0,0)
 ; 21/06/2021:	Added support for CLG and Get_Char (Modes 1 to 3)
 ; 12/07/2021:	Added Get_Character_Data
+; 13/07/2021:	JGH: API uses RGB colours, MODE resets colours
 
 			MODULE	NEXT_GRAPHICS 
 
@@ -32,13 +33,14 @@
 			include "next_graphics_L2.z80"
 
 ; Clear the screen
+; NB: Should be "clear text|graphics window"
 ;
 CLG:			LD	A, (PLOT_COLOUR)
 			JR 	1F
 CLS:			LD	A, (TEXT_BACKGROUND)
 1:			LD	C, A
 			XOR	A 
-			LD	(SCRLPOS_Y), A 
+			LD	(SCRLPOS_Y), A 		; *BUG* CLG leaves text coords alone
 			LD	(CHARPOS_X), A 
 			LD	(CHARPOS_Y), A
 			LD	A, (VIDEO_MODE)
@@ -60,8 +62,9 @@ Set_Video_Mode:		AND	3
 			DEC 	E 			; Narrow cursor for Mode 3
 			DEC 	E
 1:			CALL	NEXT_CURSOR.Initialise
-			XOR	A 
-			LD	(BORDER_COLOUR), A
+			CALL	Reset_Colours
+;			XOR	A
+;			LD	(BORDER_COLOUR), A
 			LD	L, A 
 			LD	H, A 
 			LD	(PLOTORG_X), HL 
@@ -72,6 +75,16 @@ Set_Video_Mode:		AND	3
 			DEFW	NEXT_GRAPHICS_L2.Set_Video_Mode_M1
 			DEFW	NEXT_GRAPHICS_L2.Set_Video_Mode_M2
 			DEFW	NEXT_GRAPHICS_L2.Set_Video_Mode_M3
+
+Reset_Colours:		; to do: reset palette
+			LD	A,%01000111		; White foreground
+			LD	(TEXT_FOREGROUND),A
+			LD	(PLOT_COLOUR),A
+			XOR	A			; Black background
+			LD	(TEXT_BACKGROUND),A
+;			LD	(PLOT_BACKGROUND),A
+			LD	(PLOT_MODE),A
+			LD	C, A			; Black border
 
 ; Set border colour
 ;  C: Colour
@@ -84,9 +97,21 @@ Set_Border:		LD	A, C
 
 ; Set a colour
 ;  C: Colour
+;  =%0xxxxxxx - foreground
+;  =%000fibgr - set whole ink
+;  =%001xxbgr - set ink only
+;  =%01xxxxxx - extension
+;
+;  =%1xxxxxx  - background
+;  =%100fibgr - set whole paper
+;  =%101xxbgr - set paper only
+;  =%11xxxbgr - set border
 ;  B: Mode
 ;
-Set_Text_Colour:	LD	A, (VIDEO_MODE)
+Set_Text_Colour:	CALL	RGB_to_Spectrum	; Convert to hardware colour
+			CP	192
+			JR	NC,Set_Border	; COLOUR &C0+n
+			LD	A, (VIDEO_MODE)
 			CALL	SWITCH_A
 			DEFW	NEXT_GRAPHICS_ULA.Set_Text_Colour
 			DEFW	NEXT_GRAPHICS_L2.Set_Text_Colour
@@ -97,12 +122,32 @@ Set_Text_Colour:	LD	A, (VIDEO_MODE)
 ;  C: Colour
 ;  B: Mode
 ;
-Set_Plot_Colour:	LD	A, (VIDEO_MODE)
+Set_Plot_Colour:	CALL	RGB_to_Spectrum	; Convert to hardware colour
+			AND	%10011111	; Drop non-graphics operations
+			LD	C,A
+			LD	A, (VIDEO_MODE)
 			CALL	SWITCH_A
 			DEFW	NEXT_GRAPHICS_ULA.Set_Plot_Colour
 			DEFW	NEXT_GRAPHICS_L2.Set_Plot_Colour
 			DEFW	NEXT_GRAPHICS_L2.Set_Plot_Colour
 			DEFW	NEXT_GRAPHICS_L2.Set_Plot_Colour
+
+; Convert BBC API colour to Spectrum hardware colour
+; In:  C=    BBC RGB colour
+; Out: C= A= Spectrum BRG colour
+RGB_to_Spectrum:	LD	A,C	; Get RGB colour
+			AND	7	; A=%00000BGR
+			ADD	A	; A=%0000BGR0
+			CP	8	; A=%0000BGR0 Cy=b
+			CCF		; A=%0000BGR0 Cy=B
+			ADC	0	; A=%0000BGRB
+			AND	7	; A=%00000GRB
+			XOR	C	; A=%cccccgrb
+			AND	7	; A=%00000grb
+			XOR	C	; A=%cccccGRB
+			LD	C,A	; Return back to C
+			RET
+
 
 ; Vertical scroll routines
 ;
@@ -226,8 +271,13 @@ Pixel_Bounds_Check:	LD	A, D			; If either of the high bytes
 			RET	
 
 ; Scale X and Y coordinates
-; DE: X (0 to 1279) -> (0 to 255/320/640)
-; HL: Y (0 to 1023) -> (0 to 191/256)
+; Full screen X size:  20*N -> 0 to 1279  &000 to &500-1 (eg 10-col, 20-col, 40-col, 80-col MODEs)
+;                      32*N -> 0 to 1023  &000 to &400-1 (eg 16-col, 32-col, 64-col MODEs)
+;             Y size:  32*N -> 0 to 1023  &000 to &400-1 (eg 32-line MODEs)
+;                      24*N -> 0 to  767  &000 to &300-1 (eg 24-line MODEs)
+;
+;  DE: X (0 to 1279) -> (0 to 255/320/640)
+;  HL: Y (0 to 1023) -> (0 to 191/256)
 ; 
 Transform_Coords:	LD	BC, (PLOTORG_Y)	; Add the plot origin to Y
 			ADD	HL, BC 
@@ -308,6 +358,7 @@ Transform_Div:		EXX
 ; HL: Y
 ; Returns:
 ;  A: Point value
+; NB: Underlying primitive only returns Off/On, not colour
 ;
 Point:			CALL	Pixel_Bounds_Check
 			LD	A, 0
@@ -326,13 +377,13 @@ Point:			CALL	Pixel_Bounds_Check
 ;  A: Type
 ;
 Plot:			AND	%11111000		; Ignore bottom 3 bits of type
-			CP	64			; If less than 8, it's a line
+			CP	64			; If less than 64, it's a line
 			JP	C, Plot_Line 
-			JR	Z, Plot_Point		; If it is 8, then plot a point
+			JR	Z, Plot_Point		; 64+n -> then plot a point
 			CP	80	
-			JR	Z, Plot_Triangle
+			JR	Z, Plot_Triangle	; 80+n -> draw a trangle
 			CP	144
-			JP	Z, Plot_Circle		; Check for circle
+			JP	Z, Plot_Circle		; 144+n -> draw a circle
 			RET	
 
 ; Plot a point
@@ -374,11 +425,12 @@ Plot_Triangle:		JP 	Primitive_Triangle
 
 ; Set a palette colour
 ;  A: Colour to change (0 - 255)
-;  B: R colour (3 bits)
-;  C: G colour (3 bits)
-;  D: B colour (3 bits)
+;  B: R colour (3 bits - %rrrxxxxx)
+;  C: G colour (3 bits - %gggxxxxx)
+;  D: B colour (3 bits - %bbbxxxxx)
 ;
 Set_Palette_RGB:	NEXTREG	0x40, A 		; Select the colour to change
+; this looks wrong
 			LD	A, B			; Get RED component
 			AND	%00000111		; %00000RRR
 			SWAPNIB				; %0RRR0000

--- a/next_io.z80
+++ b/next_io.z80
@@ -8,7 +8,7 @@
 ; Modinfo:
 ; 10/05/2021:	Started implementing VDU engine
 ; 11/05/2021:	Fixed bug in Scroll_Down
-; 13/05/2021:	Removed (C) symbol from keytable; 0x7F is now backspace
+; 13/05/2021:	Removed (C) symbol from keytable; 0x7F is now delete
 ; 14/05/2021:	Fixed bug in Print_Char - now preserves A
 ; 15/05/2021:	Restored (C) symbol in keytable as ASCII 0xA9; Updates for MODE command
 ; 16/05/2021:	VDU system now uses SWITCH_A
@@ -20,6 +20,8 @@
 ; 16/06/2021:	Added VDU_GS (Set graphics origin)
 ; 21/06/2021:	Added VDU_DLE (CLG)
 ; 12/07/2021:	Added VDU_ETB (UDG)
+; 13/07/2021:	JGH corrected VDU 19 count, added VDU 20, uses standard SS table, optimised CS-digit
+;		To do: cursor keys &80+n, will need editor updating
 
 			MODULE	NEXT_IO
 
@@ -48,9 +50,8 @@ Read_Keyboard:		CALL	Keyscan			; Scan the keyboard
 			INC	A			; Check for 0xFF
 			RET	Z			; Then no key has been pressed
 			DEC	A
-			LD	HL, KeyTable_Main	; Lookup the key value
+			LD	HL, KeyTable_Main	; Look up the key value
 			ADD 	HL, A
-
 			LD	A, (HL)			; Fetch the key value
 
 			CP	"A"			; Is it a letter?
@@ -75,50 +76,74 @@ Read_Keyboard:		CALL	Keyscan			; Scan the keyboard
 			LD	A, (HL)			; Get the character code
 			RET
 ;
-; It's not a letter at this point, but could be space or enter
+; It's not a letter at this point, but could be space or enter or shift
 ;
 3:			BIT	0, D 			; Check for caps
 			JR	NZ, 4F			; If pressed, we'll check for special cases
 			BIT	1, D			; Has symbol shift been pressed
 			RET	Z			; No, so just return the number
-			SUB	"0"			; Index from ASCII '0'
+			CP	"0"
+			JR	NC, SYMDIGIT		; SS+digit
+			AND	A			; $00, $0d, $20
+			JR	NZ, SYMDIGIT1
+			LD	A,2			; $02, $0d, $20
+SYMDIGIT1:		AND	3			; $02, $01, $00
+			ADD	10			; $0c, $0b, $0a
+SYMDIGIT:		AND	15			; Index from ASCII '0'
 			LD	HL, KeyTable_SS_Numeric
 			ADD	HL, A
 			LD	A, (HL)
 			RET
 ;
-; Special cases, like escape, etc. Caps shift is pressed here
+; Special cases, like escape, etc. Caps shift+nonletter is pressed here
 ;
-4:			CP	" "			; Caps Shift + Space
-			JR	NZ, 5F 
-			LD	A, 0x1B			; Return ESC
-			RET 
-5:			CP	"0"			; Caps Shift + 0
-			JR	NZ, 6F
-			LD	A, 0x7F			; Return DEL
-			RET 
-6:			CP	"5"			; Caps Shift + 5
-			JR	NZ, 7F
-			LD	A, 0x08			; Return BS
-			RET
-7:			CP	"8"			; Caps Shift + 8
-			JR	NZ, 8F
-			LD	A, 0x09			; Return HT
-			RET 
-8:			CP	"6"			; Caps Shift + 6
-			JR	NZ, 9F
-			LD	A, 0x0A			; Return LF
-			RET 
-9:			CP	"7"			; Caps Shift + 7
-			JR	NZ, 10F
-			LD	A, 0x0B			; Return VT
-			RET 
-10:			CP	"2"			; Caps Shift + 2
-			LD	B, %00100000
-			JR	Z, Toggle_Flags
-			CP	"1"
-			LD	B, %00010000
-			RET	NZ
+4:			CP	"0"
+			JR	NC, 5F			; digits
+			AND	1
+			ADD	10			; $30-$39,$3a,$3b
+5:			AND	15			; '0','9',spc,ret
+			LD	HL, KeyTable_CS_Numeric
+			ADD	HL, A
+			LD	A, (HL)
+			CP	4
+			RET	NC			; Not toggle key
+
+			LD	B, %00010000		; Toggle
+			DEC	A
+			JR	Z, Toggle_Flags		; Caps Shift + 1
+			LD	B, %00100000		; Toggle CAPS
+			
+;			CP	" "			; Caps Shift + Space
+;			JR	NZ, 5F 
+;			LD	A, 0x1B			; Return ESC
+;			RET 
+;5:			CP	"0"			; Caps Shift + 0
+;			JR	NZ, 6F
+;			LD	A, 0x7F			; Return DEL
+;			RET 
+;6:			CP	"5"			; Caps Shift + 5
+;			JR	NZ, 7F
+;			LD	A, 0x88			; Return Cursor Left
+;			RET
+;7:			CP	"8"			; Caps Shift + 8
+;			JR	NZ, 8F
+;			LD	A, 0x89			; Return Cursor Right
+;			RET 
+;8:			CP	"6"			; Caps Shift + 6
+;			JR	NZ, 9F
+;			LD	A, 0x8A			; Return Cursor Down
+;			RET 
+;9:			CP	"7"			; Caps Shift + 7
+;			JR	NZ, 10F
+;			LD	A, 0x8B			; Return Cursor Up
+;			RET 
+;10:			CP	"2"			; Caps Shift + 2
+;			LD	B, %00100000		; Toggle CAPS
+;			JR	Z, Toggle_Flags
+;			CP	"1"			; Caps Shift + 1
+;			LD	B, %00010000		; Toggle
+;			RET	NZ
+
 Toggle_Flags:		LD	A, (FLAGS)		; Toggle Caps Lock bit in flags
 			XOR	B
 			LD	(FLAGS), A
@@ -218,8 +243,8 @@ VDU_CTRL_CHAR:		CALL	SWITCH_A
 			DW	VDU_DLE			; &10 DLE - Clear graphcs area (CLG)
 			DW	VDU_DC1			; &11 DC1 - Define text colour (COLOUR n)
 			DW	VDU_DC2			; &12 DC2 - Define graphics colour (GCOL a, n)
-			DW	VDU_DC3			; &13 DC3 - Define logical colour (COLOUR l, r, g, b)
-			DW	VDU_NUL			; &14 DC4 - Restore logical colours
+			DW	VDU_DC3			; &13 DC3 - Define logical colour (COLOUR l, p, r, g, b)
+			DW	VDU_DC4			; &14 DC4 - Set to default colours
 			DW	VDU_NUL			; &15 NAK - Disable VDU drivers or delete current line
 			DW	VDU_SYN			; &16 SYN - Select screen mode (MODE n)
 			DW	VDU_ETB			; &17 ETB - Define display character and other commands; used by ON and OFF
@@ -313,14 +338,14 @@ VDU_DC2:		LD	B, 2 			; 2 bytes (mode, colour)
 			LD	A, 3 			; State 3: GCOL
 			JR	VDU_SET_STATE
 
-; &12 DC3 - COLOUR a, r, g, b
+; &13 DC3 - COLOUR n, p, r, g, b
 ;
-VDU_DC3:		LD	B, 4			; 4 bytes (colour, r, g, b)
+VDU_DC3:		LD	B, 5			; 5 bytes (colour, p, r, g, b)
 			LD	A, 2 			; State 2: COLOUR
 			JR	VDU_SET_STATE
 
 ; &16 SYN - MODE n
-VDU_SYN:		LD	B, 1			; 1 byte (colour)
+VDU_SYN:		LD	B, 1			; 1 byte (mode)
 			LD	A, 5 			; State 5: MODE
 			JR	VDU_SET_STATE
 
@@ -379,25 +404,36 @@ VDU_EXEC_PLOT:		LD	HL, (PLOTPOS_X)		; Store the previous plot points
 			LD	(PLOTPOS_Y), HL
 			JP	NEXT_GRAPHICS.Plot
 
+; VDU 20: Reset colours
+;
+VDU_DC4:		JP	NEXT_GRAPHICS.Reset_Colours
+
 ; COLOUR:
 ; VDU 17,colour
-; VDU 19,colour,r,g,b
 ;
 VDU_EXEC_COLOUR:	LD	A, (VDU_PTR)		; Check number of parameters
-			CP	4			; If 4, then it is VDU 19,colour,r,g,b
-			JR	Z, 1F
+			CP	5			; If 5, then it is VDU 19,colour,p,r,g,b
+			JR	NC, 1F
 			DEC	A			
-			RET	NZ
+			RET	NZ			; Not 1, not VDU 17, exit
 			LD	B, 0			; If 1, then it is VDU 17,colour
 			LD	C, (IX + 0)
 			JP	NEXT_GRAPHICS.Set_Text_Colour
-1:			LD	A, (IX + 0)		; Get the palette colour to change
-			LD	B, (IX + 1)		; Get the R component
-			LD	C, (IX + 2)		; Get the G component
-			LD	D, (IX + 3)		; Get the B component
+
+; VDU 19,colour,phys,red,grn,blu
+;               0-15,ign,ign,ign
+;               16+ ,red,grb,blu - component strength %0.... to %1....
+1:			LD	A, (IX + 1)
+			CP	16
+			JR	NC, 2F			; Set palette components
+; to do, convert physical colour to palette components
+2:			LD	A, (IX + 0)		; Get the palette colour to change
+			LD	B, (IX + 2)		; Get the R component
+			LD	C, (IX + 3)		; Get the G component
+			LD	D, (IX + 4)		; Get the B component
 			JP	NEXT_GRAPHICS.Set_Palette_RGB
 
-; GCOL: VDU 18,mode,,colour
+; GCOL: VDU 18,mode,colour
 ;
 VDU_EXEC_GCOL:		LD	A, (VDU_BUFFER + 0)
 			LD	(PLOT_MODE), A 
@@ -413,9 +449,12 @@ VDU_EXEC_TAB:		LD	A, (VDU_BUFFER + 0)
 			LD	(CHARPOS_Y), A
 			RET 
 
-; MODE: VDU 16,mode
-;
+; MODE: VDU 22,mode
+; To do: map 0,3 -> 80col
+;            1,4 -> 40col
+;            ?   -> 32col
 VDU_EXEC_MODE:		LD	A, (VDU_BUFFER + 0)
+			XOR	3
 			JP 	NEXT_GRAPHICS.Set_Video_Mode
 
 ; Set graphics origin
@@ -439,7 +478,7 @@ VDU_EXEC_UDG:		LD	HL, VDU_BUFFER
 			RET
 
 ; Scan the keyboard
-; A modified version of the ZX Spectum 48K rom routine
+; A modified version of the ZX Spectum 48K ROM routine
 ; Returns:
 ;  E: Keycode (in the range 0 to 39), or 0xFF if no key pressed
 ;  D: Shift code - bit 0: caps, bit 1: symbol
@@ -488,13 +527,24 @@ KeyTable_Main:		DB	"B", "H", "Y", "6", "5", "T", "G", "V"
 			DB	$00, "L", "O", "9", "2", "W", "S", "Z"
 			DB	$20, $0D, "P", "0", "1", "Q", "A", $00
 
-KeyTable_SS_Numeric:	DB 	"_", "!", "@", "#", "$", "%", "&", "'", "(", ")"
-KeyTable_SS_Alpha:	DB	"~", "*", "?", $5C
-			DB	$00, "{", "}", "^"
-			DB	$00, "-", "+", "="
-			DB	".", ",", ";", $22
-			DB	$A9, "<", "|", ">"
-			DB	"]", "/", $00, $60
+KeyTable_CS_Numeric:
+;			DB	$7f, $01, $02, $83, $84, $88, $8A, $8B, $89, $89, $1b, $0d
+			DB	$7f, $01, $02, $83, $84, $08, $0A, $0B, $09, $89, $1b, $0d
+			;	 0    1    2    3    4    5    6    7    8    9   spc  ret
+
+KeyTable_SS_Numeric:	DB 	"_", "!", "@", "#", "$", "%", "&", "'", "(", ")", $20, $0d, $09
+			;	 0    1    2    3    4    5    6    7    8    9   spc  ret  ext
+
+KeyTable_SS_Alpha:	DB	"~", "*", "?", $5C, $87, "{", "}", "^"
+			;	 a    b    c    d    e    f    g    h
+			DB	$A9, "-", "+", "=", ".", ",", ";", $22
+			;	 i    j    k    l    m    n    o    p
+			DB	$85, "<", "|", ">", "]", "/", $86, $60
+			;	 q    r    s    t    u    v    w    x
 			DB	"[", ":"
+			;	 y    z
+
+; Available additional key combinations:
+; CS-RET, SS-SPC, SS-RET
 
 			ENDMODULE

--- a/patch.z80
+++ b/patch.z80
@@ -24,12 +24,17 @@
 ; 05/07/2021:	Added OPT, OSOPEN, OSSHUT, OSBGET, OSBPUT, OSSTAT, GETPTR and PUTPTR
 ; 10/07/2021:	Fixed bug in PUTCSR and optimised PUTSCR and GETCSR; Modified GET_PORT and PUT
 ; 14/07/2021:	JGH: MODE sends to OSWRCH, OSBYTE 0 returns L=ZX Spectrum, INKEY(neg) returns, INKEY-256 returns machine
+; 14/07/2021:	JGH: Got INKEY Carry wrong way around. JGH: DOH! Forgot to remove RET from OSCALL.
 
 			MODULE PATCH
 
 @GETIMS:		EQU	NEXT_RTC.GET_DATE_STRING	; Get the time string from the real-time clock module
 @OSWRCH:		EQU	NEXT_IO.Print_Char		; Write a character out
 @OSLINE			EQU 	EDITOR.Edit_Line		; Line editor
+
+;; These two seems to have vanished from the source
+;SPTONULL	RET
+;SKIPNOTSP	RET
 
 ; MODE n: Set video mode
 ;
@@ -100,6 +105,7 @@
 ;   Inputs: HL = time limit (centiseconds)
 ;  Outputs: Carry reset if time-out
 ;           If carry set A = character
+; ***NB*** Carry is opposite to BBC API
 ; Destroys: A,H,L,F
 ;
 @OSKEY:			BIT	7,H
@@ -134,10 +140,11 @@ ESCTEST:		LD	A, (KEYCODE)
 			JR	NZ,OSNEGKEY1	; Not INKEY(0xFFxx)
 			LD	A,L
 			AND	A		; Is it INKEY(0xFF00) ?
-			LD	HL,0x00E8	; INKEY-256 -> ZX Spectrum Next
+			LD	A,0xE8		; INKEY-256 -> ZX Spectrum Next
+			SCF			; Carry=Ok - NB! Opposite to BBC API
 			RET	Z
-OSNEGKEY1:		LD	HL,0		; All other INKEY(-key) -> FALSE
-			AND	A		; Clear Carry
+OSNEGKEY1:		LD	A,0		; All other INKEY(-key) -> FALSE
+			SCF			; Carry=Ok - NB! Opposite to BBC API
 			RET			; To do, add keyboard scanning
 
 ;
@@ -798,14 +805,14 @@ SETOPT:			LD	(OPTVAL), A
 
 ; ----------------------------------------------------------------------------
 
-: BBC API MOS Call
+; BBC API MOS Call
 ; CALL &FFxx/USR &FFxx
 ;
 ; IY=destination, &FF00+nn
 ; IX=>resident variables
 ; SP=>return to raw call, return to exec loop
 ;
-@OSCALL:		RET
+@OSCALL:
 ;IF MOVEOS
 ;	DEFB &FD		; LD IYH
 ;	LD   H,&FF		; Modify entry point address

--- a/patch.z80
+++ b/patch.z80
@@ -1,9 +1,10 @@
 ;
-; Title:	BBC Basic Interpreter - Z80 version
+; Title:	BBC BASIC Interpreter - Z80 version
 ;		Patch file for Spectrum Next
+;		I/O layer between BASIC and the host
 ; Author:	Dean Belfield
 ; Created:	02/05/2021
-; Last Updated:	10/07/2021
+; Last Updated:	14/07/2021 JGH
 ;
 ; Modinfo:
 ; 09/05/2021:	Fixed plot mode and bug in COMDS table
@@ -22,6 +23,7 @@
 ; 15/06/2021:	Plot, Draw, Move and Line now call Transform_Coords
 ; 05/07/2021:	Added OPT, OSOPEN, OSSHUT, OSBGET, OSBPUT, OSSTAT, GETPTR and PUTPTR
 ; 10/07/2021:	Fixed bug in PUTCSR and optimised PUTSCR and GETCSR; Modified GET_PORT and PUT
+; 14/07/2021:	JGH: MODE sends to OSWRCH, OSBYTE 0 returns L=ZX Spectrum, INKEY(neg) returns, INKEY-256 returns machine
 
 			MODULE PATCH
 
@@ -33,8 +35,10 @@
 ;
 @MODE:			CALL    EXPRI
 			EXX
+			LD	A, 22
+			CALL	OSWRCH
 			LD	A, L
-			CALL	NEXT_GRAPHICS.Set_Video_Mode
+			CALL	OSWRCH
 			JP	XEQ
 
 ; CLG: clear the graphics screen
@@ -98,7 +102,9 @@
 ;           If carry set A = character
 ; Destroys: A,H,L,F
 ;
-@OSKEY:			LD	A, (KEYCODE)	; Read keyboard
+@OSKEY:			BIT	7,H
+			JR	NZ,@OSNEGKEY	; Negative INKEY
+@OSKEYLOOP:		LD	A, (KEYCODE)	; Read keyboard
 			OR	A		; If we have a character
 			JR	NZ, 1F		; Then process it
 			LD	A,H		; Check if HL is 0 (this is passed by INKEY() function
@@ -106,7 +112,7 @@
 			RET	Z 		; If it is then ret
 			HALT			; Bit of a bodge so this is timed in ms
 			DEC	HL 		; Decrement the counter and 
-			JR	@OSKEY 		; loop
+			JR	@OSKEYLOOP	; loop
 1:			CP	0x1B		; If we are not pressing ESC, 
 			SCF 			; then flag we've got a character
 			RET	NZ		
@@ -123,6 +129,17 @@ ESCTEST:		LD	A, (KEYCODE)
 			CP	0x1B		; ESC	
 			JR	Z,ESCSET
 			RET
+;
+@OSNEGKEY:		INC	H
+			JR	NZ,OSNEGKEY1	; Not INKEY(0xFFxx)
+			LD	A,L
+			AND	A		; Is it INKEY(0xFF00) ?
+			LD	HL,0x00E8	; INKEY-256 -> ZX Spectrum Next
+			RET	Z
+OSNEGKEY1:		LD	HL,0		; All other INKEY(-key) -> FALSE
+			AND	A		; Clear Carry
+			RET			; To do, add keyboard scanning
+
 ;
 @TRAP:			CALL	ESCTEST
 @LTRAP:			LD	A,(FLAGS)
@@ -144,7 +161,7 @@ ESCTEST:		LD	A, (KEYCODE)
          		CALL	NEXT_INIT.Reserve_UDG	; Reserve RAM for UDG; returns DE = RAMTOP
          		LD 	HL, @USER
 			XOR	A
-			LD	(@FLAGS), A		; Clear flags and set F = Z
+			LD	(@FLAGS), A		; Clear flags and set Z=no command line
          		RET	
 
 ;OSCLI - Process an "operating system" command
@@ -287,7 +304,7 @@ STAR_FX:		CALL	ASC_TO_NUMBER
 			JR	Z, STAR_FX_19 
 			CP	20
 			JR	Z, STAR_FX_20
-			JP 	HUH
+			RET
 
 ; OSCLI FX 19: Wait 1/50th of a second
 ;
@@ -781,9 +798,49 @@ SETOPT:			LD	(OPTVAL), A
 
 ; ----------------------------------------------------------------------------
 
-; Stuff not implemented yet
-; There's also more stuff in sorry.z80
+: BBC API MOS Call
+; CALL &FFxx/USR &FFxx
+;
+; IY=destination, &FF00+nn
+; IX=>resident variables
+; SP=>return to raw call, return to exec loop
 ;
 @OSCALL:		RET
+;IF MOVEOS
+;	DEFB &FD		; LD IYH
+;	LD   H,&FF		; Modify entry point address
+;ENDIF
+	LD   HL,OSCALLRETURN
+	EX   (SP),HL		; Replace return address
+	LD   A,(IX+4)		; Get A from A%
+	LD   E,(IX+20)		; Get E from E%
+	LD   H,(IX+100)		; Get H from Y%
+	LD   L,(IX+96)		; Get L from X%
+;
+; for the mo...
+	PUSH IY
+	POP  BC
+	LD   A,C		; Low byte of MOS address
+	CP   0xF4
+	LD   A,(IX+4)		; Get A from A%
+	RET  NZ			; Ignore everything except OSBYTE
+	AND  A
+	RET  NZ			; Ignore everything except OSBYTE 0
+	LD   L,31		; L=31=ZX Spectrum
+	RET
+;	
+;	JP   (IY)		; Jump to entry point
+@OSCALLRETURN:
+	PUSH AF			; Form return value from FHLA
+	LD   A,L
+	LD   L,H
+	EXX
+	POP  BC
+	LD   H,A
+	LD   L,B
+	LD   A,C
+	EXX
+	LD   H,A
+	RET
 
 			ENDMODULE


### PR DESCRIPTION
next_io, KBD:
Optimised CAPS-Digit processing
SS/CS+space/enter don't return out of range values
Use standard SS table: if no EXTEND mode, then SS-I is used for (C),
see http://mdfs.net/Info/Comp/Spectrum/ProgTips/Editors/

next_io, VDU:
Added VDU 20, calls ResetColours
Corrected VDU 19 count

next_graphics:
MODE resets colours (calls VDU 20)
API uses RGB colours
see http://mdfs.net/Software/BBCBasic/Testing/VDU/img/Colours.htm
and http://mdfs.net/Info/Comp/BBC/Display/Colours/Physical.htm

